### PR TITLE
Google Calendar doesn't recognize AM/PM

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -139,7 +139,7 @@ $(document).ready(function() {
 
 	function gCalLink(date) {
 		var end = date.clone().add(1, 'seconds');
-		var format = 'YYYYMMDD[T]hhmmss[Z]';
+		var format = 'YYYYMMDD[T]HHmmss[Z]';
 		var baseUrl = "http://www.google.com/calendar/event?";
 		var params = {
 			action: 'TEMPLATE',


### PR DESCRIPTION
I _think_ this fixes the issue, but I haven't tested it. My billionth second is `September 22nd 2019, 6:48:40 am PDT`. However, when I go to at it at Google Calendar, gCal thinks that I want `PM` and not `AM`.